### PR TITLE
fix compile error on cargo test

### DIFF
--- a/nal_eval/tests/fixture.rs
+++ b/nal_eval/tests/fixture.rs
@@ -14,6 +14,7 @@ use std::cell::RefCell;
 
 use serde_yaml::from_str as yaml;
 
+use nal_ast::ast::common::{Ast, Ident};
 use nal_eval::{eval, Value, Env};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -47,7 +48,7 @@ fn eval_print(src: &str) -> Vec<SValue> {
         Ok(Value::Unit)
     }));
 
-    env.decl("print", print);
+    env.decl(&Ast::dummy(Ident(Rc::from("print"))), print);
 
     match eval(src, &mut env) {
         Err(e) => panic!("Failed to eval: {:?}", e),


### PR DESCRIPTION
`cargo test` fails with the following message:
```
$ cargo test
   Compiling nal_eval v0.1.0 (path/to/Nal/nal_eval)
error[E0308]: mismatched types
  --> fixture.rs:51:14
   |
51 |     env.decl(Ast::dummy(Ident(Rc::from("print"))), print);
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found struct `nal_ast::ast::common::Ast`
   |
   = note: expected type `&nal_ast::ast::common::Ast<nal_ast::ast::common::Ident>`
              found type `nal_ast::ast::common::Ast<nal_ast::ast::common::Ident>`
   = help: try with `&Ast::dummy(Ident(Rc::from("print")))`

error: aborting due to previous error

error: Could not compile `nal_eval`.

To learn more, run the command again with --verbose.
```
This pull request fixes this.